### PR TITLE
did-resize Refactoring

### DIFF
--- a/addon/modifiers/did-resize.js
+++ b/addon/modifiers/did-resize.js
@@ -9,21 +9,24 @@ export default class DidResizeModifier extends Modifier {
   observer = null;
 
   observe() {
-    if ('ResizeObserver' in window) {
-      this.observer = new ResizeObserver((entries, observer) => {
-        this.handler(entries[0], observer);
-      });
-
+    if (this.observer) {
       this.observer.observe(this.element, this.options);
     }
   }
 
   unobserve() {
     if (this.observer) {
+      this.observer.unobserve();
+    }
+  }
+
+  disconnect() {
+    if (this.observer) {
       this.observer.disconnect();
     }
   }
 
+  // Stop observing temporarily on update in case options have changed
   didUpdateArguments() {
     this.unobserve();
   }
@@ -38,7 +41,19 @@ export default class DidResizeModifier extends Modifier {
     this.observe();
   }
 
+  didInstall() {
+    if (!('ResizeObserver' in window)) {
+      return;
+    }
+
+    this.observer = new ResizeObserver((entries, observer) => {
+      this.handler(entries[0], observer);
+    });
+
+    this.observe();
+  }
+
   willRemove() {
-    this.unobserve();
+    this.disconnect();
   }
 }

--- a/tests/integration/modifiers/did-resize-test.js
+++ b/tests/integration/modifiers/did-resize-test.js
@@ -6,6 +6,7 @@ import sinon from 'sinon';
 
 let resizeCallback;
 let observeStub;
+let unobserveStub;
 let disconnectStub;
 let MockResizeObserver;
 
@@ -17,6 +18,7 @@ module('Integration | Modifier | did-resize', function (hooks) {
   hooks.beforeEach(function () {
     resizeCallback = null;
     observeStub = sinon.stub();
+    unobserveStub = sinon.stub();
     disconnectStub = sinon.stub();
 
     MockResizeObserver = class MockResizeObserver {
@@ -25,6 +27,7 @@ module('Integration | Modifier | did-resize', function (hooks) {
       }
 
       observe = observeStub;
+      unobserve = unobserveStub;
       disconnect = disconnectStub;
     }
 
@@ -79,5 +82,17 @@ module('Integration | Modifier | did-resize', function (hooks) {
 
     assert.notOk(resizeCallback, 'no callback received');
     assert.notOk(observeStub.calledOnce, 'observe was not called');
+  });
+
+  test('modifier calls unobserve when arguments change', async function (assert) {
+    await render(hbs`<div {{did-resize this.resizeStub}}></div>`);
+
+    assert.notOk(unobserveStub.called, 'unobserve not called yet');
+    assert.ok(observeStub.calledOnce, 'observe was called');
+
+    this.set('resizeStub', sinon.stub());
+
+    assert.ok(unobserveStub.calledOnce, 'unobserve called');
+    assert.ok(observeStub.calledTwice, 'observe was called again');
   });
 });


### PR DESCRIPTION
- Instantiate the observer only in didInstall
- Capture arguments in didReceiveArguments
- Unobserve on updates in case arguments changed
- Disconnect only when removing the modifier