### PR TITLE
Use single ResizeObserver for better performance

### DIFF
--- a/tests/integration/modifiers/did-resize-test.js
+++ b/tests/integration/modifiers/did-resize-test.js
@@ -101,4 +101,52 @@ module('Integration | Modifier | did-resize', function (hooks) {
     assert.ok(unobserveStub.calledOnce, 'unobserve called');
     assert.ok(observeStub.calledTwice, 'observe was called again');
   });
+
+  test('handlers are setup and called correctly when multiple modifiers are present', async function (assert) {
+    this.setProperties({
+      resizeStub2: sinon.stub(),
+      resizeStub3: sinon.stub(),
+    });
+
+    await render(
+      hbs`<div id="test-element1" {{did-resize this.resizeStub}}></div>
+        <div id="test-element2" {{did-resize this.resizeStub2}}></div>
+        <div id="test-element3" {{did-resize this.resizeStub3}}></div>`
+    );
+
+    let entries = ['#test-element1', '#test-element2', '#test-element3'].map(
+      (elementId) => {
+        return { target: find(elementId) };
+      }
+    );
+    let fakeObserver = { observe: {} };
+
+    // trigger resize on all elements
+    resizeCallback(entries, fakeObserver);
+
+    assert.ok(this.resizeStub.calledOnce, 'First handler was called only once');
+    assert.ok(
+      this.resizeStub2.calledOnce,
+      'Second handler was called only once'
+    );
+    assert.ok(
+      this.resizeStub3.calledOnce,
+      'Third handler was called only once'
+    );
+
+    // trigger resize only on the first element
+    resizeCallback([entries[0]], fakeObserver);
+    assert.ok(
+      this.resizeStub.calledTwice,
+      'First handler was called a second time'
+    );
+    assert.notOk(
+      this.resizeStub2.calledTwice,
+      'Second handler was not called a second time'
+    );
+    assert.notOk(
+      this.resizeStub3.calledTwice,
+      'Third handler was not called a second time'
+    );
+  });
 });

--- a/tests/integration/modifiers/did-resize-test.js
+++ b/tests/integration/modifiers/did-resize-test.js
@@ -3,16 +3,17 @@ import { setupRenderingTest } from 'ember-qunit';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
+import DidResizeModifier from 'ember-resize-modifier/modifiers/did-resize';
 
 module('Integration | Modifier | did-resize', function (hooks) {
   setupRenderingTest(hooks);
 
   let resizeCallback = null;
-  const observeStub = sinon.stub();
-  const unobserveStub = sinon.stub();
-  const disconnectStub = sinon.stub();
-  const resizeObserver = window.ResizeObserver;
-  const mockResizeObserver = class MockResizeObserver {
+  let observeStub = sinon.stub();
+  let unobserveStub = sinon.stub();
+  let disconnectStub = sinon.stub();
+  let resizeObserver = window.ResizeObserver;
+  let mockResizeObserver = class MockResizeObserver {
     constructor(callback) {
       resizeCallback = callback;
     }
@@ -28,6 +29,11 @@ module('Integration | Modifier | did-resize', function (hooks) {
     disconnectStub.reset();
     this.resizeStub = sinon.stub();
     window.ResizeObserver = mockResizeObserver;
+
+    // reset static properties to make sure every test case runs independently
+    DidResizeModifier.observer = null;
+    DidResizeModifier.handlers = null;
+    resizeCallback = null;
   });
 
   hooks.afterEach(function () {
@@ -80,7 +86,7 @@ module('Integration | Modifier | did-resize', function (hooks) {
     delete window.ResizeObserver;
 
     await render(hbs`<div {{did-resize this.resizeStub}}></div>`);
-
+    assert.notOk(resizeCallback, 'no callback received');
     assert.notOk(observeStub.calledOnce, 'observe was not called');
   });
 


### PR DESCRIPTION
According to the guidelines of using the `ResizeObserver` API the recommended approach is to use a single observer to observe multiple elements because it provides significant performance gains compared to creating a new observer for each element.