### PR TITLE
Fix issue 328 by using requestAnimationFrame

### DIFF
--- a/addon/modifiers/did-resize.js
+++ b/addon/modifiers/did-resize.js
@@ -19,10 +19,12 @@ export default class DidResizeModifier extends Modifier {
     if (!DidResizeModifier.observer) {
       DidResizeModifier.handlers = new WeakMap();
       DidResizeModifier.observer = new ResizeObserver((entries, observer) => {
-        for (let entry of entries) {
-          const handler = DidResizeModifier.handlers.get(entry.target);
-          if (handler) handler(entry, observer);
-        }
+        window.requestAnimationFrame(() => {
+          for (let entry of entries) {
+            const handler = DidResizeModifier.handlers.get(entry.target);
+            if (handler) handler(entry, observer);
+          }
+        });
       });
     }
   }


### PR DESCRIPTION
Addresses #328. Wrap the `ResizeObserver` callback in a `requestAnimationFrame` to fix `ResizeObserver loop limit exceeded` exceptions. 

Note: This may not be a perfect solution. See dialog on this response in stack overflow https://stackoverflow.com/a/58701523/985641.