### PR TITLE
Make embroider-safe build required

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,13 +58,12 @@ jobs:
           - ember-lts-3.28
           - ember-release
           - ember-classic
+          - embroider-safe
         experimental: [false]
         include:
           - try-scenario: ember-beta
             experimental: true
           - try-scenario: ember-canary
-            experimental: true
-          - try-scenario: embroider-safe
             experimental: true
           - try-scenario: embroider-optimized
             experimental: true


### PR DESCRIPTION
* Now that it's passing, don't let it regress