### PR TITLE
Performance: avoid creating callbacks for the destructor

### DIFF
--- a/addon/modifiers/did-resize.js
+++ b/addon/modifiers/did-resize.js
@@ -30,11 +30,11 @@ export default class DidResizeModifier extends Modifier {
       });
     }
 
-    registerDestructor(this, (instance) => instance.unobserve());
+    registerDestructor(this, unobserve);
   }
 
   modify(element, positional /*, named*/) {
-    this.unobserve();
+    unobserve(this);
 
     this.element = element;
 
@@ -54,18 +54,22 @@ export default class DidResizeModifier extends Modifier {
     }
   }
 
-  unobserve() {
-    if (this.element && DidResizeModifier.observer) {
-      DidResizeModifier.observer.unobserve(this.element);
-      this.removeHandler();
-    }
-  }
-
   addHandler() {
     DidResizeModifier.handlers.set(this.element, this.handler);
   }
 
   removeHandler() {
     DidResizeModifier.handlers.delete(this.element);
+  }
+}
+
+/**
+ *
+ * @param {DidResizeModifier} instance
+ */
+function unobserve(instance) {
+  if (instance.element && DidResizeModifier.observer) {
+    DidResizeModifier.observer.unobserve(instance.element);
+    instance.removeHandler();
   }
 }


### PR DESCRIPTION
Extract `unobserve` to a function in module scope which accepts an instance as its public argument, and use that when calling `registerDestructor` as well as at the start of every `modify` call. This results in having exactly one function allocated for the destructor to call, instead of a function per instance. This is a relatively small win, but a meaningful one which might add up significantly if you have many of these on a given page.