### PR TITLE
Move ember-auto-import to dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "test:ember-compatibility": "ember try:each"
   },
   "dependencies": {
+    "ember-auto-import": "^2.5.0",
     "ember-cli-babel": "^7.26.11",
     "ember-cli-htmlbars": "^6.1.1",
     "ember-modifier": "^3.2.0"
@@ -42,7 +43,6 @@
     "@glimmer/tracking": "^1.1.2",
     "broccoli-asset-rev": "^3.0.0",
     "concurrently": "^7.6.0",
-    "ember-auto-import": "^2.5.0",
     "ember-cli": "~4.9.2",
     "ember-cli-dependency-checker": "^3.3.1",
     "ember-cli-deprecation-workflow": "^2.0.0",


### PR DESCRIPTION
With ember-modifier v4, it's now required to make e-a-i a dep instead of devDep. See also: https://github.com/ember-modifier/ember-modifier/issues/602