### PR TITLE
Embroider compatible with dynamic components

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -16,6 +16,7 @@ module.exports = function (defaults) {
 
   const { maybeEmbroider } = require('@embroider/test-setup');
   return maybeEmbroider(app, {
+    staticComponents: false,
     skipBabel: [
       {
         package: 'qunit',


### PR DESCRIPTION
- Workaround for Embroider test

```shell
ERROR in ../../node_modules/field-guide/templates/components/dynamic-template.hbs
Module build failed (from ../../../../../home/runner/work/ember-resize-modifier/ember-resize-modifier/node_modules/thread-loader/dist/cjs.js):
Thread Loader (Worker 0)
$TMPDIR/embroider/6678d4/node_modules/field-guide/templates/components/dynamic-template.hbs: Unsafe dynamic component: this.componentName in $TMPDIR/embroider/6678d4/node_modules/field-guide/templates/components/dynamic-template.hbs

 @ ../../node_modules/field-guide/components/dynamic-template.js 5:0-62 13:2-8
 @ ./components/dynamic-template.js 2:0-88 2:0-88
 @ ../../node_modules/field-guide/templates/show.hbs 2:0-82 13:30-45
 @ ./templates/show.js 1:0-75 1:0-75
 @ ./assets/dummy.js 63:13-44
```

This PR in field-guide should fix the issue:
[Support Embroider](https://github.com/empress/field-guide/pull/53)