### PR TITLE
ember-try v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,16 +54,17 @@ jobs:
         try-scenario:
           - ember-lts-3.28
           - ember-lts-4.4
+          - ember-lts-4.8
+          - ember-lts-4.12
           - ember-release
           - ember-classic
           - embroider-safe
+          - embroider-optimized
         experimental: [false]
         include:
           - try-scenario: ember-beta
             experimental: true
           - try-scenario: ember-canary
-            experimental: true
-          - try-scenario: embroider-optimized
             experimental: true
 
     steps:

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "ember-source": "~4.12.0",
     "ember-source-channel-url": "^3.0.0",
     "ember-template-lint": "^5.11.2",
-    "ember-try": "^2.0.0",
+    "ember-try": "^3.0.0",
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-ember": "^11.11.1",
@@ -86,7 +86,7 @@
     "node": "14.* || 16.* || >= 18"
   },
   "volta": {
-    "node": "14.21.1",
+    "node": "18.12.0",
     "yarn": "1.22.19"
   },
   "publishConfig": {

--- a/tests/dummy/config/ember-try.js
+++ b/tests/dummy/config/ember-try.js
@@ -24,6 +24,22 @@ module.exports = async function () {
         },
       },
       {
+        name: 'ember-lts-4.8',
+        npm: {
+          devDependencies: {
+            'ember-source': '~4.8.0',
+          },
+        },
+      },
+      {
+        name: 'ember-lts-4.12',
+        npm: {
+          devDependencies: {
+            'ember-source': '~4.12.0',
+          },
+        },
+      },
+      {
         name: 'ember-release',
         npm: {
           devDependencies: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6255,10 +6255,10 @@ ember-try-config@^4.0.0:
     remote-git-tags "^3.0.0"
     semver "^7.3.2"
 
-ember-try@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ember-try/-/ember-try-2.0.0.tgz#2671c221f5a0335fa2c189d00db7146e2e72a1dd"
-  integrity sha512-2N7Vic45sbAegA5fhdfDjVbEVS4r+ze+tTQs2/wkY+8fC5yAGHfCM5ocyoTfBN5m7EhznC3AyMsOy4hLPzHFSQ==
+ember-try@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ember-try/-/ember-try-3.0.0.tgz#3b4e8511b64925aff14224b408fb5b5adab69391"
+  integrity sha512-ZYVKYWMnrHSD3vywo7rV76kPCOC9ATIEnGGG/PEKfCcFE0lB26jltRDnOrhORfLKq0JFp62fFxC/4940U+MwRQ==
   dependencies:
     chalk "^4.1.2"
     cli-table3 "^0.6.0"
@@ -6266,9 +6266,10 @@ ember-try@^2.0.0:
     debug "^4.3.2"
     ember-try-config "^4.0.0"
     execa "^4.1.0"
-    fs-extra "^9.0.1"
+    fs-extra "^6.0.1"
     resolve "^1.20.0"
     rimraf "^3.0.2"
+    semver "^7.5.4"
     walk-sync "^2.2.0"
 
 emoji-regex@^7.0.1:
@@ -12630,7 +12631,7 @@ semver@^6.0.0, semver@^6.1.0, semver@^6.1.1, semver@^6.1.2, semver@^6.2.0, semve
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.0.0, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8:
+semver@^7.0.0, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8, semver@^7.5.4:
   version "7.5.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
   integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==


### PR DESCRIPTION
Also bumps to Node 18 and adds more Ember 4 test scenarios, as well as making embroider-optimized a required scenario now that it's passing.